### PR TITLE
Refactor Tool Serialization and Provider Integration:

### DIFF
--- a/src/main/kotlin/robot/provider/models/LocalAI.kt
+++ b/src/main/kotlin/robot/provider/models/LocalAI.kt
@@ -9,11 +9,12 @@ import dev.supachain.robot.provider.Actions
 import dev.supachain.robot.provider.Provider
 import dev.supachain.robot.provider.CommonChatRequest
 import dev.supachain.robot.provider.responses.OpenAIChatResponse
-import dev.supachain.robot.messenger.messaging.OpenAIFunctionListSerializer
 import dev.supachain.robot.*
 import dev.supachain.robot.NetworkOwner
 import dev.supachain.robot.director.DirectorCore
 import dev.supachain.robot.messenger.messaging.Message
+import dev.supachain.robot.provider.tools.OpenAITool
+
 import dev.supachain.robot.tool.ToolConfig
 import dev.supachain.robot.tool.strategies.BackAndForth
 import dev.supachain.robot.tool.strategies.ToolUseStrategy
@@ -89,10 +90,13 @@ private interface LocalAIAPI : Extension<LocalAI> {
         val model: String,
         val messages: List<Message>,
         val temperature: Double,
-        @SerialName("top_p") val topP: Double,
-        @SerialName("top_k") val topK: Int,
-        @SerialName("max_tokens") val maxTokens: Int,
-        @Serializable(with = OpenAIFunctionListSerializer::class)
+        @SerialName("top_p")
+        val topP: Double,
+        @SerialName("top_k")
+        val topK: Int,
+        @SerialName("max_tokens")
+        val maxTokens: Int,
+        @Serializable(with = OpenAITool::class)
         val functions: List<ToolConfig> = emptyList(),
     ) : CommonChatRequest
 }

--- a/src/main/kotlin/robot/provider/models/Ollama.kt
+++ b/src/main/kotlin/robot/provider/models/Ollama.kt
@@ -6,7 +6,7 @@ import dev.supachain.robot.NetworkOwner
 import dev.supachain.robot.director.DirectorCore
 import dev.supachain.robot.provider.CommonChatRequest
 import dev.supachain.robot.messenger.messaging.Message
-import dev.supachain.robot.messenger.messaging.OpenAIFunctionListSerializer
+import dev.supachain.robot.provider.tools.OpenAITool
 import dev.supachain.robot.post
 import dev.supachain.robot.provider.Actions
 import dev.supachain.robot.provider.Provider
@@ -38,7 +38,7 @@ private interface OllamaApi : Extension<LocalAI> {
     data class ChatRequest(
         val model: String,
         val messages: List<Message>,
-        @Serializable(with = OpenAIFunctionListSerializer::class)
+        @Serializable(with = OpenAITool::class)
         val tools: List<ToolConfig> = emptyList(),
         val stream: Boolean
     ) : CommonChatRequest

--- a/src/main/kotlin/robot/provider/tools/OpenAITool.kt
+++ b/src/main/kotlin/robot/provider/tools/OpenAITool.kt
@@ -1,56 +1,26 @@
-@file:Suppress("unused")
-
-package dev.supachain.robot.messenger.messaging
+package dev.supachain.robot.provider.tools
 
 import dev.supachain.robot.tool.ToolConfig
-import dev.supachain.utilities.SerializeWrite
 import dev.supachain.utilities.Parameter
 import dev.supachain.utilities.toJSONSchemaType
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.builtins.ListSerializer
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.encoding.Encoder
 
-/**
- * Serializes a list of `ToolConfig` objects into a format compatible with OpenAI function calls.
- *
- * This serializer transforms a list of `ToolConfig` objects, which represent tool configurations, into
- * a list of `OpenAiFunctionSchema` objects. This conversion is necessary for proper communication with the
- * OpenAI API, which expects function descriptions in a specific format.
- *
- * @since 0.1.0-alpha
+internal class OpenAITool: SerialToolList<OpenAITool.Schema>() {
+    @Serializable
+    data class Schema(
+        var name: String,
+        var description: String,
+        var parameters: OpenAIFunctionParams
+    )
 
- */
-internal class OpenAIFunctionListSerializer : SerializeWrite<List<ToolConfig>> {
-    override val descriptor: SerialDescriptor = ListSerializer(OpenAIFunctionSchema.serializer()).descriptor
-
-    override fun serialize(encoder: Encoder, value: List<ToolConfig>) {
-        encoder.encodeSerializableValue(
-            ListSerializer(OpenAIFunctionSchema.serializer()),
-            value.map { OpenAIFunctionSchema(it) })
-    }
-}
-
-/**
- * Represents a tool function description in the format expected by servers using the OpenAI Schema
- *
- * @property name The name of the tool function.
- * @property description A description of the tool function's purpose and functionality.
- * @property parameters A `OpenAIFunctionParams` object containing the parameter details.
- *
- * @since 0.1.0-alpha
- */
-@Serializable
-internal data class OpenAIFunctionSchema(
-    val name: String,
-    val description: String,
-    val parameters: OpenAIFunctionParams
-) {
-    constructor(toolConfig: ToolConfig) : this(
+    override fun serialTool(toolConfig: ToolConfig) = Schema(
         toolConfig.function.name,
         toolConfig.function.description,
         OpenAIFunctionParams(toolConfig.function.parameters)
     )
+
+    override fun toolSerializer(): KSerializer<Schema> = Schema.serializer()
 }
 
 /**

--- a/src/main/kotlin/robot/provider/tools/ToolSerializations.kt
+++ b/src/main/kotlin/robot/provider/tools/ToolSerializations.kt
@@ -1,0 +1,34 @@
+@file:Suppress("unused")
+
+package dev.supachain.robot.provider.tools
+
+import dev.supachain.robot.tool.ToolConfig
+import dev.supachain.utilities.SerializeWrite
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Encoder
+
+/**
+ * Serializes a list of `ToolConfig` objects into a format compatible with OpenAI function calls.
+ *
+ * This serializer transforms a list of `ToolConfig` objects, which represent tool configurations, into
+ * a list of `OpenAiFunctionSchema` objects. This conversion is necessary for proper communication with the
+ * OpenAI API, which expects function descriptions in a specific format.
+ *
+ * @since 0.1.0-alpha
+
+ */
+abstract class SerialToolList<T> : SerializeWrite<List<ToolConfig>> {
+    abstract fun serialTool(toolConfig: ToolConfig): T
+    abstract fun toolSerializer(): KSerializer<T>
+
+    override val descriptor: SerialDescriptor by lazy { ListSerializer(toolSerializer()).descriptor }
+
+    // Converts List<ToolConfig> into the toolSerializer format
+    override fun serialize(encoder: Encoder, value: List<ToolConfig>) {
+        encoder.encodeSerializableValue(
+            ListSerializer(toolSerializer()),
+            value.map { serialTool(it) })
+    }
+}


### PR DESCRIPTION
**Description**
This pull request improves the project's modularity and flexibility by decoupling tool serialization from the messenger and introducing a generic SerialToolList for tool serialization. This allows for easier integration of future providers with different API syntax requirements.

**Key Changes**
- Moved OpenAIFunctionListSerializer to provider.tools for better modularity.
- Introduced SerialToolList for generic tool serialization.
- Updated LocalAI and Ollama to use OpenAITool for serialization

**Benefits**
- Improved code structure and maintainability.
- Enhanced flexibility for future provider integration

Close #102 